### PR TITLE
fixes #58

### DIFF
--- a/cifsdk/utils.py
+++ b/cifsdk/utils.py
@@ -13,13 +13,14 @@ def read_config(args):
         config = config['client']
         f.close()
         if not config:
-            raise Exception("Unable to read {} config file".format(args.config))
+            print("Unable to read {} config file".format(args.config))
+            raise SystemExit
         for k in config:
             if not options.get(k):
                 options[k] = config[k]
-
     else:
-        raise Exception("Unable to read {} config file".format(args.config))
+        print("Unable to read {} config file".format(args.config))
+        raise SystemExit
 
     return options
 


### PR DESCRIPTION
so what about this... 

```
$ cif -C /home/.cif.yml -q example.com
Unable to read /home/.cif.yml config file
```

many less words to read