### PR TITLE
Quick changes in the example to fix syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ bin/cif command on the server. This SDK is meant to be used as a client interact
   from cifsdk.client import Client
   from cifsdk.format import Table
 
-  cli = Client(token=1234,
+  cli = Client(token='1234',
                remote='https://localhost',
-               no_verify_ssl=1)
+               verify_ssl=False)
   
   
   ret = cli.search('example.com')
@@ -56,11 +56,11 @@ bin/cif command on the server. This SDK is meant to be used as a client interact
    ```python
    from cifsdk.client import Client
 
-   d = '{"observable":"example4.com","tlp":"amber","confidence":"85","tags":"malware","provider":"example.com","group":"everyone"}'
+   data = '{"observable":"example4.com","tlp":"amber","confidence":"85","tags":"malware","provider":"example.com","group":"everyone"}'
 
-   cli = Client(token=1234,
+   cli = Client(token='1234',
                remote='https://localhost',
-               no_verify_ssl=1)
+               verify_ssl=False)
 
    ret = cli.submit(data)
    print("submission id: {0}".format(ret))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The CIF  Software Development Kit (SDK) for Python contains library code and exa
 bin/cif command on the server. This SDK is meant to be used as a client interacting with a REMOTE CIF Instance.**
 
 # Installation
- 
+
 ## Ubuntu
   ```bash
   $ sudo apt-get install -y python-dev python-pip git
@@ -38,16 +38,16 @@ bin/cif command on the server. This SDK is meant to be used as a client interact
   cli = Client(token='1234',
                remote='https://localhost',
                verify_ssl=False)
-  
-  
+
+
   ret = cli.search('example.com')
   print Table(ret)
-  
+
   filters = {
     "observable": "example.com",
     "confidence": 35,
   }
-  
+
   ret = cli.search(filters=filters)
   print(Table(ret))
   ```


### PR DESCRIPTION
Just made a couple of quick updates to some of the examples in the README. 

The dictionary for the ```cli.submit``` had the wrong name and I also changed the token from an ```int``` to a ```string```. If someone tries to put their token in without the quotes it won't work. 

Also, I was getting errors using ```no_verify_ssl```. It looks like it is ```verify_ssl```. I used ```False``` as its value. I also removed some whitespace. 

Let me know if you have any questions or if I am on the wrong track.